### PR TITLE
Fix 4 bugs affecting ViT depth, MoE eval-noise, LPEG ordering, and LPEG freezing

### DIFF
--- a/model/MoE.py
+++ b/model/MoE.py
@@ -138,13 +138,14 @@ class ExpertChoiceTokenNoisyTopkRouter(nn.Module):
 
     def forward(self, mh_output):
         logits = self.topkroute_linear(mh_output).reshape(-1, self.num_experts).T
-        noise_logits = self.noise_linear(mh_output).reshape(-1, self.num_experts).T
 
-        noise = torch.randn_like(logits) * F.softplus(noise_logits)
-        noisy_logits = logits + noise
+        if self.training:
+            noise_logits = self.noise_linear(mh_output).reshape(-1, self.num_experts).T
+            noise = torch.randn_like(logits) * F.softplus(noise_logits)
+            logits = logits + noise
 
-        top_k_logits, indices = noisy_logits.topk(self.top_k, dim=-1)
-        zeros = torch.full_like(noisy_logits, float('-inf'))
+        top_k_logits, indices = logits.topk(self.top_k, dim=-1)
+        zeros = torch.full_like(logits, float('-inf'))
         sparse_logits = zeros.scatter(-1, indices, top_k_logits)
         router_output = F.softmax(sparse_logits, dim=-1)
         return router_output, indices

--- a/segment_anything_ESAM/modeling/image_encoder.py
+++ b/segment_anything_ESAM/modeling/image_encoder.py
@@ -113,14 +113,18 @@ class ImageEncoderViT(nn.Module):
         )
 
     def forward(self, x: torch.Tensor, features=None) -> torch.Tensor:
+        x = self.patch_embed(x)
+        if self.pos_embed is not None:
+            x = x + self.pos_embed
+
         output = []
         block_number = [0,1,2,3,4,5,6,7,8,9,10,11]
         for i,blk in enumerate(self.blocks):
             x = blk(x)
             if i in block_number:
                 output.append(x)
-            x = self.neck(x.permute(0, 3, 1, 2))
-            return x, output
+        x = self.neck(x.permute(0, 3, 1, 2))
+        return x, output
 
 
 class AttentionFusion(nn.Module):

--- a/segment_anything_ESAM/modeling/sam_my.py
+++ b/segment_anything_ESAM/modeling/sam_my.py
@@ -222,9 +222,6 @@ class Sam_my(nn.Module):
 
         input_images = self.preprocess(batched_input)
         image_embeddings, low_image_embeddings = self.image_encoder(input_images)
-        sparse_embeddings, dense_embeddings = self.prompt_encoder(
-                points=None, boxes=None, masks=None, image_embedding=image_embeddings
-        )
 
         embedding_moe = torch.cat([embed.unsqueeze(1) for embed in low_image_embeddings], dim=1).permute(0, 1, 4, 2, 3).contiguous()
 
@@ -235,6 +232,14 @@ class Sam_my(nn.Module):
         embedding_moe = self.attn(embedding_moe, embedding_moe, embedding_moe).reshape(bs, num_features, h, w, dim).permute(0, 1, 4, 2, 3).contiguous()
         embedding_moe = embedding_moe.mean(1)
         image_embeddings = image_embeddings + self.neck5(embedding_moe)
+
+        # LPEG (inlined in prompt_encoder.forward when image_embedding is
+        # passed) is described in the paper as consuming the MoE-FEB
+        # enhanced embedding ("enhanced image embeddings" as LPEG's input),
+        # so this must run after the MoE-FEB block above, not before it.
+        sparse_embeddings, dense_embeddings = self.prompt_encoder(
+                points=None, boxes=None, masks=None, image_embedding=image_embeddings
+        )
 
         low_res_masks, iou_predictions = self.mask_decoder(
                 image_embeddings=image_embeddings,

--- a/train.py
+++ b/train.py
@@ -105,8 +105,16 @@ def main():
             value.requires_grad = False
         else:
             value.requires_grad = True
+    # The Lightweight Prompt Embedding Generator (LPEG) -- prompt_encoder's
+    # layernorm/fc1/fc2 submodules, inlined in PromptEncoder.forward -- is
+    # randomly initialized (it has no counterpart in the pretrained SAM
+    # checkpoint) and is one of the components the paper says is
+    # fine-tuned (Sec. 2: "fine-tunes the adapters, feature enhancing
+    # block, prompt embedding generator, and mask decoder"). Freezing it
+    # here left it at its random initialization for the entire run.
+    lpeg_param_names = ("layernorm", "fc1", "fc2")
     for n, value in sam.prompt_encoder.named_parameters():
-        value.requires_grad = False
+        value.requires_grad = any(name in n for name in lpeg_param_names)
 
     net1 = sam.cuda()
 


### PR DESCRIPTION
## Summary

While reproducing MoE-SAM on our own multiclass abdominal CT datasets (AMOS22, Synapse/BTCV), we ran into training instability that traced back to four independent bugs in the released code. This PR fixes all four; each commit is self-contained and can be reviewed/reverted independently.

## Bugs fixed

**1. `ImageEncoderViT.forward()` only runs 1 of 12 transformer blocks**
`return x, output` is indented inside the `for i, blk in enumerate(self.blocks)` loop, so the method returns after the very first block. The other 11 blocks are constructed and initialized but never executed on any forward pass. The same method also never calls `self.patch_embed(x)` or adds `self.pos_embed`, despite both being built in `__init__` — the raw pixel tensor goes straight into block 0 instead of a patch-embedded, position-encoded sequence.

**2. `ExpertChoiceTokenNoisyTopkRouter` adds noise even during eval**
The Gaussian exploration noise (`torch.randn_like(logits) * F.softplus(noise_logits)`) is added unconditionally, including under `model.eval()`/`torch.no_grad()`. This makes expert routing non-deterministic at inference time — the same checkpoint on the same input can route tokens to different experts and produce different predictions/metrics on repeated evaluations. Gated behind `if self.training`, matching how e.g. `nn.Dropout` behaves.

**3. LPEG (self-prompting) runs on the pre-MoE-FEB image embedding**
`Sam_my.forward()` calls `self.prompt_encoder(..., image_embedding=image_embeddings)` *before* computing and adding `embedding_moe` back into `image_embeddings`. The paper describes LPEG as consuming the "enhanced image embeddings" — i.e. after MoE-FEB fusion — so the prompt encoder call is moved to after the MoE-FEB block.

**4. LPEG is frozen for the entire run**
`train.py` sets `requires_grad = False` on every parameter in `sam.prompt_encoder`, which now also includes LPEG's `layernorm`/`fc1`/`fc2` layers. LPEG has no pretrained weights in the SAM checkpoint (it starts randomly initialized), and the paper explicitly lists it among the fine-tuned components (Sec. 2: "fine-tunes the adapters, feature enhancing block, prompt embedding generator, and mask decoder"). As written, LPEG never learns anything and produces a fixed, random prompt embedding for the whole run.

## Why this matters

Bugs 3 and 4 compound: LPEG was both getting the wrong input *and* never training, so the self-prompting mechanism was effectively inert. Combined with bug 2's eval-time noise, this made ablations involving MoE-FEB + LPEG together unstable to reproduce — we saw training collapse to a degenerate near-background prediction on two different multiclass CT datasets until all four fixes were applied.

## Testing

Verified on our own fork/framework port (not included here) with AMOS22 (16-class) and Synapse/BTCV (14-class) abdominal CT: before these fixes, the full MoE-FEB+LPEG configuration collapsed to near-zero Dice on both; after, both train to a healthy, non-degenerate Dice comparable to the MoE-FEB-only baseline.

## Related open issues

We also ran into the reproducibility gaps reported in #1, #3, #4, and #5 (missing `datasets/dataset_MMWHS.py`, unclear MMWHS/BTCV split methodology) while investigating this — flagging in case it's useful context, though this PR doesn't attempt to address those.
